### PR TITLE
Change default 1 to 0 for False representation on Eject function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ read -e -p "2. Do you want to use Eject-CD key as Delete? [y/N]: " -i "N" yn
     case $yn in
         [Yy]* ) EJECTCD_AS_DELETE=1; echo "Yes, use it";;
         [Nn]* ) EJECTCD_AS_DELETE=0; echo "No, don't";;
-        * ) 	EJECTCD_AS_DELETE=1; echo "No (default)";;
+        * ) 	EJECTCD_AS_DELETE=0; echo "No (default)";;
     esac
     
 echo ""


### PR DESCRIPTION
I noticed the default was still 1 for the eject case, changed this to 0 to accurately represent the string instructions.
