### PR TITLE
Add build and install targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,12 @@
+LINUX_HEADER_DIR ?=/usr/src/linux-headers-$(uname -r)
+
 obj-$(CONFIG_HID_APPLE)		+= hid-apple.o
+
+all:
+	make -C $(LINUX_HEADER_DIR) M=$(CURDIR) modules
+
+clean:
+	make -C $(LINUX_HEADER_DIR) M=$(CURDIR) clean
+
+install:
+	make -C $(LINUX_HEADER_DIR) M=$(CURDIR) modules_install


### PR DESCRIPTION
- Add build target.
- Add install target.
- Use overridable environment variable for kernel headers path
