### PR TITLE
Trivial fix for concurrent rightalt_as_rightctrl and swap_opt_cmd

### DIFF
--- a/hid-apple.c
+++ b/hid-apple.c
@@ -289,6 +289,14 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
 		}
 	}
 
+	if (rightalt_as_rightctrl) {
+		trans = apple_find_translation(rightalt_as_rightctrl_keys, usage->code);
+		if (trans) {
+			input_event(input, usage->type, trans->to, value);
+			return 1;
+		}
+	}
+
 	if (swap_opt_cmd) {
 		trans = apple_find_translation(swapped_option_cmd_keys, usage->code);
 		if (trans) {
@@ -307,14 +315,6 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
 
 	if (ejectcd_as_delete) {
 		trans = apple_find_translation(ejectcd_as_delete_keys, usage->code);
-		if (trans) {
-			input_event(input, usage->type, trans->to, value);
-			return 1;
-		}
-	}
-
-	if (rightalt_as_rightctrl) {
-		trans = apple_find_translation(rightalt_as_rightctrl_keys, usage->code);
 		if (trans) {
 			input_event(input, usage->type, trans->to, value);
 			return 1;


### PR DESCRIPTION
Trivially refactors the code such that the rightalt_as_rightctrl conditional is evaluated before the swap_opt_cmd conditional.  In consequence, rightalt_as_rightctrl and swap_opt_cmd may be used concurrently.

Have been using this without issue for approximately one year on a Macbook 7,1 running Ubuntu 16.04, with parameters:

fnmode:1
ejectcd_as_delete:1
swap_fn_leftctrl:1
rightalt_as_rightctrl:1
iso_layout:1
swap_opt_cmd:1