### PR TITLE
Add wired keyboard support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,11 @@ clean:
 
 install:
 	make -C $(LINUX_HEADER_DIR) M=$(CURDIR) modules_install
+
+# - alternative installs
+
+test-install:
+	sudo /bin/sh -c "rmmod -f hid-apple && insmod hid-apple.ko"
+
+test-uninstall:
+	-sudo /bin/sh -c "rmmod -f hid-apple && modprobe hid-apple"

--- a/README.md
+++ b/README.md
@@ -60,14 +60,22 @@ The advantage of DKMS is that the module is automatically re-built after every k
 Permanent configuration is done in file `/etc/modprobe.d/hid_apple.conf`. The format is one option-value pair per line, like `swap_fn_leftctrl=1`. After writing to the file, do `sudo update-initramfs -u` and reboot.
 Temporary configuration (applies immediately but is lost after rebooting) is possible by writing to virtual files in `/sys/module/hid_apple/parameters/`, like `echo 1 | sudo tee /sys/module/hid_apple/parameters/swap_fn_leftctrl`.
 
+Options already in mainstream kernels:
+
 - `fnmode` - Mode of top-row keys
   - `0` = disabled
   - `1` = normally media keys, switchable to function keys by holding Fn key (Default)
   - `2` = normally function keys, switchable to media keys by holding Fn key
-- `swap_fn_leftctrl` - Swap the Fn and left Control keys
+- `swap_opt_cmd` - Swap the Option (\"Alt\") and Command (\"Flag\") keys
   - `0` = as silkscreened, Mac layout (Default)
   - `1` = swapped, PC layout
-- `swap_opt_cmd` - Swap the Option (\"Alt\") and Command (\"Flag\") keys
+- `iso_layout` - Enable/Disable hardcoded ISO-layout of the keyboard. Possibly relevant for international keyboard layouts
+  - `0` = disabled, 
+  - `1` = enabled (Default)
+
+Apple wireless keyboard support (FN at bottom left):
+
+- `swap_fn_leftctrl` - Swap the Fn and left Control keys
   - `0` = as silkscreened, Mac layout (Default)
   - `1` = swapped, PC layout
 - `rightalt_as_rightctrl` - Use the right Alt key as a right Ctrl key
@@ -76,9 +84,15 @@ Temporary configuration (applies immediately but is lost after rebooting) is pos
 - `ejectcd_as_delete` - Use Eject-CD key as Delete key, if available
   - `0` = disabled (Default)
   - `1` = enabled
-- `iso_layout` - Enable/Disable hardcoded ISO-layout of the keyboard. Possibly relevant for international keyboard layouts
-  - `0` = disabled, 
-  - `1` = enabled (Default)
+
+Apple wired keyboard support (has numpad and F1 through F19):
+
+- `swap_f13_14_15_to_sysrq_scrlock_pause` - Swaps F13,F14,F15 with SYSRQ,SCROLLLOCK,PAUSE kays
+  - `0` = as silkscreened, Mac layout (Default)
+  - `1` = swapped, PC layout
+- `swap_fn_f19_and_insert_fn` - F19 becomes FN, and FN becomes INSERT key
+  - `0` = as silkscreened, Mac layout (Default)
+  - `1` = swapped, PC layout
 
 
 ### Warning regarding Secure Boot (on non-Apple computers)


### PR DESCRIPTION
* adding `swap_f13_14_15_to_sysrq_scrlock_pause` option to swap F13,F14,F15 to SYSRQ,SCROLLLOCK,PAUSE keys
* adding `swap_fn_f19_and_insert_fn` option to move FN to F19, and add INSERT at FN's place

Additional:
* Adding `make {test-install,test-uninstall}` targets for easy switch between drivers