### PR TITLE
Add fnesc_toggle to be able to toggle the fn key

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Temporary configuration (applies immediately but is lost after rebooting) is pos
 - `iso_layout` - Enable/Disable hardcoded ISO-layout of the keyboard. Possibly relevant for international keyboard layouts
   - `0` = disabled, 
   - `1` = enabled (Default)
+- `fnesc_toggle` - Use Fn + Esc together to toggle the `fnmode` between `1` and `2`. Requires `fnmode` to be non zero.
+  - `0` = disabled,
+  - `1` = enabled (Default)
 
 
 ### Warning regarding Secure Boot (on non-Apple computers)

--- a/hid-apple.c
+++ b/hid-apple.c
@@ -68,6 +68,11 @@ module_param(ejectcd_as_delete, uint, 0644);
 MODULE_PARM_DESC(ejectcd_as_delete, "Use Eject-CD key as Delete key. "
 		"([0] = disabled, 1 = enabled)");
 
+static unsigned int fnesc_toggle = 1;
+module_param(fnesc_toggle, uint, 0644);
+MODULE_PARM_DESC(fnesc_toggle, "Use fn+esc to toggle fnmode between 1 and 2 (fnmode must be > 0). "
+		"(0 = disabled, [1] = enabled)");
+
 struct apple_sc {
 	unsigned long quirks;
 	unsigned int fn_on;
@@ -223,6 +228,11 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
 	}
 
 	if (fnmode) {
+		if (fnesc_toggle && asc->fn_on && usage->code == KEY_ESC) {
+			fnmode = (fnmode == 1) ? 2 : 1;
+			return 1;
+		}
+
 		int do_translate;
 
 		if (hid->product >= USB_DEVICE_ID_APPLE_WELLSPRING4_ANSI &&


### PR DESCRIPTION
This fixes #35.

This adds a new option: `fnesc_toggle` which, when set to `1` adds the <kbd>fn</kbd> + <kbd>esc</kbd> keybinding that automatically switches `fnmode` between `1` and `2`.

I chose <kbd>fn</kbd> + <kbd>esc</kbd> since all the non-Apple laptops I've owned (mostly Dells) have this keybinding, so as far as I know it's kind of a standard.

---

Right now, when using this patch users need to press <kbd>fn</kbd> + <kbd>esc</kbd> to toggle the `fnmode`. 

I've noticed that it _doesn't_ work if you hold down <kbd>fn</kbd> and then press <kbd>esc</kbd> after a short delay... It only seems to work if you press them rather quickly (maybe something to do with key-repeat?).