### PR TITLE
Add an option to have CapsLock be (another) left Control

### DIFF
--- a/hid-apple.c
+++ b/hid-apple.c
@@ -73,6 +73,11 @@ module_param(ejectcd_as_delete, uint, 0644);
 MODULE_PARM_DESC(ejectcd_as_delete, "Use Eject-CD key as Delete key. "
 		"([0] = disabled, 1 = enabled)");
 
+static unsigned int capslock_as_leftctrl = 0;
+module_param(capslock_as_leftctrl, uint, 0644);
+MODULE_PARM_DESC(capslock_as_leftctrl, "CapsLock is an additional left Control key. "
+		"([0] = disabled, 1 = enabled)");
+
 struct apple_sc {
 	unsigned long quirks;
 	unsigned int fn_on;
@@ -202,6 +207,11 @@ static const struct apple_key_translation rightalt_as_rightctrl_keys[] = {
 
 static const struct apple_key_translation ejectcd_as_delete_keys[] = {
 	{ KEY_EJECTCD,	KEY_DELETE },
+	{ }
+};
+
+static const struct apple_key_translation capslock_as_leftctrl_keys[] = {
+	{ KEY_CAPSLOCK, KEY_LEFTCTRL },
 	{ }
 };
 
@@ -355,6 +365,14 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
 		}
 	}
 
+	if (capslock_as_leftctrl) {
+		trans = apple_find_translation(capslock_as_leftctrl_keys, usage->code);
+		if (trans) {
+			input_event(input, usage->type, trans->to, value);
+			return 1;
+		}
+	}
+
 	return 0;
 }
 
@@ -431,6 +449,11 @@ static void apple_setup_input(struct input_dev *input)
 
 	if (ejectcd_as_delete) {
 		for (trans = ejectcd_as_delete_keys; trans->from; trans++)
+			set_bit(trans->to, input->keybit);
+	}
+
+	if (capslock_as_leftctrl) {
+		for (trans = capslock_as_leftctrl_keys; trans->from; trans++)
 			set_bit(trans->to, input->keybit);
 	}
 


### PR DESCRIPTION
Hi and thanks for this work!

I had been remapping capslock to control with setxkbmap, but when using this bluetooth keyboard A1314, that setting would stop working occasionally and I would START YELLING and have to log out and back in.  Putting the option here instead fixes that.