### PR TITLE
Add option to use Lock key as Delete key

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ And these options were added in the patched version:
 - `ejectcd_as_delete` - Use Eject-CD key as Delete key, if available
   - `0` = disabled (Default)
   - `1` = enabled
+- `lock_as_delete` - Use Lock key as Delete key, if available
+  - `0` = disabled (Default)
+  - `1` = enabled
 - `swap_fn_f13_insert` - Swap the Fn and f13 keys, making Fn Insert and f13 Fn. For people who need Insert
   - `0` = disabled (Default), 
   - `1` = enabled

--- a/hid-apple.c
+++ b/hid-apple.c
@@ -73,6 +73,11 @@ module_param(ejectcd_as_delete, uint, 0644);
 MODULE_PARM_DESC(ejectcd_as_delete, "Use Eject-CD key as Delete key. "
 		"([0] = disabled, 1 = enabled)");
 
+static unsigned int lock_as_delete;
+module_param(lock_as_delete, uint, 0644);
+MODULE_PARM_DESC(lock_as_delete, "Use Lock key as Delete key. "
+		"([0] = disabled, 1 = enabled)");
+
 static unsigned int capslock_as_leftctrl;
 module_param(capslock_as_leftctrl, uint, 0644);
 MODULE_PARM_DESC(capslock_as_leftctrl, "CapsLock is an additional left Control key. "
@@ -207,6 +212,11 @@ static const struct apple_key_translation rightalt_as_rightctrl_keys[] = {
 
 static const struct apple_key_translation ejectcd_as_delete_keys[] = {
 	{ KEY_EJECTCD,	KEY_DELETE },
+	{ }
+};
+
+static const struct apple_key_translation lock_as_delete_keys[] = {
+	{ KEY_COFFEE,	KEY_DELETE },
 	{ }
 };
 
@@ -365,6 +375,14 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
 		}
 	}
 
+	if (lock_as_delete) {
+		trans = apple_find_translation(lock_as_delete_keys, usage->code);
+		if (trans) {
+			input_event(input, usage->type, trans->to, value);
+			return 1;
+		}
+	}
+
 	if (capslock_as_leftctrl) {
 		trans = apple_find_translation(capslock_as_leftctrl_keys, usage->code);
 		if (trans) {
@@ -449,6 +467,11 @@ static void apple_setup_input(struct input_dev *input)
 
 	if (ejectcd_as_delete) {
 		for (trans = ejectcd_as_delete_keys; trans->from; trans++)
+			set_bit(trans->to, input->keybit);
+	}
+
+	if (lock_as_delete) {
+		for (trans = lock_as_delete_keys; trans->from; trans++)
 			set_bit(trans->to, input->keybit);
 	}
 

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ PLACE_FOR_MODULE="/lib/modules/$(uname -r)/kernel/drivers/hid"
 SWAP_FN_F13_INSERT=0
 SWAP_FN_LEFTCTRL=0
 EJECTCD_AS_DELETE=0
+LOCK_AS_DELETE=0
 
 # Pre-checks -------------------------------------------
 # Check if place for module exists in system
@@ -75,6 +76,15 @@ read -e -p "3. Do you want to use Eject-CD key as Delete? [y/N]: " -i "N" yn
         [Nn]* ) EJECTCD_AS_DELETE=0; echo "No, don't";;
         * )   EJECTCD_AS_DELETE=0; echo "No (default)";;
     esac
+echo ""
+
+echo "NOTE: If you don't have Lock key, select No (default)"
+read -e -p "3. Do you want to use Lock key as Delete? [y/N]: " -i "N" yn
+    case $yn in
+        [Yy]* ) LOCK_AS_DELETE=1; echo "Yes, use it";;
+        [Nn]* ) LOCK_AS_DELETE=0; echo "No, don't";;
+        * )   LOCK_AS_DELETE=0; echo "No (default)";;
+    esac
 
 echo ""
 echo "============================================="
@@ -100,7 +110,7 @@ if [ -f "$MODULE_OPTIONS_PATH/swap_opt_cmd" ]; then
 fi
 
 sudo rmmod "$MODULE_LSMOD_NAME"
-sudo insmod "./$MODULE_FILENAME" $SAVED_OPTIONS swap_fn_leftctrl="$SWAP_FN_LEFTCTRL" ejectcd_as_delete="$EJECTCD_AS_DELETE" swap_fn_f13_insert="$SWAP_FN_F13_INSERT"
+sudo insmod "./$MODULE_FILENAME" $SAVED_OPTIONS swap_fn_leftctrl="$SWAP_FN_LEFTCTRL" ejectcd_as_delete="$EJECTCD_AS_DELETE" lock_as_delete="$LOCK_AS_DELETE" swap_fn_f13_insert="$SWAP_FN_F13_INSERT"
 
 echo "The patched module was loaded."
 echo "Please test the keyboard (mainly the modified keys)."
@@ -157,6 +167,15 @@ if [ $SEARCH_RESULT_EJECTCD -gt "0" ]; then
 else
 	echo "" | sudo tee -a "$MODPROBE_CONFIG_PATH"
 	echo "options hid_apple ejectcd_as_delete=$EJECTCD_AS_DELETE" | sudo tee -a "$MODPROBE_CONFIG_PATH"
+fi
+
+SEARCH_RESULT_LOCK=`cat "$MODPROBE_CONFIG_PATH" | grep "lock_as_delete" | wc -l`
+if [ $SEARCH_RESULT_LOCK -gt "0" ]; then
+	echo "Warning: Option 'lock_as_delete' is already set in $MODPROBE_CONFIG_PATH"
+	echo "You should change this option manually in this file"
+else
+	echo "" | sudo tee -a "$MODPROBE_CONFIG_PATH"
+	echo "options hid_apple lock_as_delete=$LOCK_AS_DELETE" | sudo tee -a "$MODPROBE_CONFIG_PATH"
 fi
 
 


### PR DESCRIPTION
Apple's Magic Keyboard 2 is available with Touch ID or Lock key. This commit adds an option to use the Lock key as Delete key.