### PR TITLE
Kernel 6.12 function signature update

### DIFF
--- a/hid-apple.c
+++ b/hid-apple.c
@@ -422,7 +422,7 @@ static int apple_event(struct hid_device *hdev, struct hid_field *field,
 /*
  * MacBook JIS keyboard has wrong logical maximum
  */
-static __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static const __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 		unsigned int *rsize)
 {
 	struct apple_sc *asc = hid_get_drvdata(hdev);

--- a/hid-apple.c
+++ b/hid-apple.c
@@ -14,6 +14,7 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/version.h>
 #include <linux/device.h>
 #include <linux/hid.h>
 #include <linux/module.h>
@@ -422,8 +423,13 @@ static int apple_event(struct hid_device *hdev, struct hid_field *field,
 /*
  * MacBook JIS keyboard has wrong logical maximum
  */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+static __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+		unsigned int *rsize)
+#else
 static const __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 		unsigned int *rsize)
+#endif
 {
 	struct apple_sc *asc = hid_get_drvdata(hdev);
 


### PR DESCRIPTION
The report_fixup() function signature was changed in kernel version 6.12.0 to improve security and support constified static report arrays. See https://github.com/torvalds/linux/commit/fe73965d078670406acee0218f118c0870d6a58b

To ensure compatibility with older kernels, this patch introduces a kernel version check for the apple_report_fixup() function:

- Kernels < 6.12.0: The return type is kept as __u8 *.
- Kernels >= 6.12.0: The return type is updated to const __u8 * as required by the newer kernel versions.

This change prevents breakage on older kernel versions while still using the updated function signature on newer kernels.

Successfully tested on Arch Linux 6.12.4 and Ubuntu 5.15.11.

fixes #99

@free5lot, could you please review this patch?