### PR TITLE
Fix kernel >=6.12 const return type & improve DKMS compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-LINUX_HEADER_DIR ?= /usr/src/linux-headers-$(shell uname -r)
+ifeq ($(KERNELRELEASE),)
+    LINUX_HEADER_DIR ?= /usr/src/linux-headers-$(shell uname -r)
+else
+    # dkms or kernel build -> use proper build dir
+    LINUX_HEADER_DIR ?= /lib/modules/$(KERNELRELEASE)/build
+endif
 
 obj-$(CONFIG_HID_APPLE)		+= hid-apple.o
 

--- a/hid-apple.c
+++ b/hid-apple.c
@@ -16,6 +16,13 @@
 
 #include <linux/device.h>
 #include <linux/hid.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+#define FIXUP_CONST /* empty */
+#else
+#define FIXUP_CONST const
+#endif
 #include <linux/module.h>
 #include <linux/slab.h>
 
@@ -422,7 +429,7 @@ static int apple_event(struct hid_device *hdev, struct hid_field *field,
 /*
  * MacBook JIS keyboard has wrong logical maximum
  */
-static __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+static FIXUP_CONST __u8 *apple_report_fixup(struct hid_device *hdev, __u8 *rdesc,
 		unsigned int *rsize)
 {
 	struct apple_sc *asc = hid_get_drvdata(hdev);


### PR DESCRIPTION
The signature of apple_report_fixup changed in kernel 6.12. 
This pull request addresses the issue while keeping backwards compatibility.
Furthermore it fixes an issue with dkms auto install, where the module is still build against the headers of the running kernel instead of those of that is beeing installed. Now the KERNELRELEASE env var provided by DKMS is used (if set) to ensure that the module is built against the correct kernel headers.